### PR TITLE
Load eldldr.elf from a Remote Http Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# ELF Loader for BD-J [ps5-jar-loader](https://github.com/hammer-83/ps5-jar-loader)
+# ELF Loader for BD-J [ez-ps5-jar-loader](https://github.com/cy33hc/ps5-jar-loader)
 
 ## Usage
 
-- Download and burn the iso release of [ps5-jar-loader](https://github.com/hammer-83/ps5-jar-loader/releases/latest) onto a BluRay Disc.
+- Download and burn the iso release of [ez-ps5-jar-loader](https://github.com/cy33hc/ps5-jar-loader/releases/latest) onto a BluRay Disc.
 - Run the UMTX payload from the disc or send via remote option.
-- Use the remote jar loader option to send the elfloader.jar payload to your PS5.
+- Send the elfloader.jar payload to your PS5.
 - There are multiple options available for sending:
 
 ### Netcat

--- a/src/main/java/org/ps5jb/client/payloads/ElfLoader.java
+++ b/src/main/java/org/ps5jb/client/payloads/ElfLoader.java
@@ -33,7 +33,7 @@ public class ElfLoader implements Runnable {
     private ProcessUtils procUtils;
     private SdkInit sdk;
 
-    String elfUrl = "http://151.145.35.129:8000/elfldr.elf";
+    String elfUrl = "http://172.245.146.114:8000/elfldr.elf";
 
     private boolean init() {
         try {

--- a/src/main/java/org/ps5jb/client/payloads/ElfLoader.java
+++ b/src/main/java/org/ps5jb/client/payloads/ElfLoader.java
@@ -33,7 +33,7 @@ public class ElfLoader implements Runnable {
     private ProcessUtils procUtils;
     private SdkInit sdk;
 
-    String elfUrl = "http://192.168.100.135:9000/document/en/ps5/payloads/elfldr.elf";
+    String elfUrl = "http://151.145.35.129:8000/elfldr.elf";
 
     private boolean init() {
         try {


### PR DESCRIPTION
Refactored the ELFLoader to pull down the elfldr.elf from a http server. Currently I've hardcoded the URL to my server http://151.145.35.129:8000

This avoids having to burn a new BDJ disc when elfldr.elf is updated. I've also submitted a PR to ps5-jar-loader Developer to embed this into it also. https://github.com/hammer-83/ps5-jar-loader/pull/14